### PR TITLE
chore(build): upgrade Node engine to 22.x for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tailwindcss": "^3.3.0"
   },
   "engines": {
-    "node": "18.20.x",
+    "node": "22.x",
     "npm": ">=8.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Atualiza engines.node para 22.x porque Node 18 será bloqueado a partir de 01/09