### PR TITLE
ci(lhci): stabilize desktop runs (3x devtools; budgets unchanged)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,10 +1,11 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 1,
+      "numberOfRuns": 3,
       "settings": {
         "preset": "desktop"
-      }
+      },
+      "throttlingMethod": "devtools"
     },
     "assert": {
       "assertions": {

--- a/lighthouserc.mobile.json
+++ b/lighthouserc.mobile.json
@@ -3,8 +3,14 @@
     "collect": {
       "numberOfRuns": 1,
       "settings": {
-        "preset": "mobile",
-        "throttlingMethod": "devtools"
+        "formFactor": "mobile",
+        "screenEmulation": {
+          "mobile": true,
+          "width": 360,
+          "height": 640,
+          "deviceScaleFactor": 2,
+          "disabled": false
+        }
       },
       "url": [
         "https://crset-solutions-frontend.vercel.app/",
@@ -12,9 +18,14 @@
         "https://crset-solutions-frontend.vercel.app/precos",
         "https://crset-solutions-frontend.vercel.app/centro-de-ajuda",
         "https://crset-solutions-frontend.vercel.app/faq"
-      ]
+      ],
+      "throttlingMethod": "devtools"
     },
-    "assert": { "assertions": {} },
-    "upload": { "target": "temporary-public-storage" }
+    "assert": {
+      "assertions": {}
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
   }
 }


### PR DESCRIPTION
Executa LHCI desktop 3x com throttling devtools para reduzir flakiness. Budgets e URLs mantidos.