### PR TITLE
ci(lhci-mobile): add warn-level asserts + stabilize (2 runs devtools)

### DIFF
--- a/lighthouserc.mobile.json
+++ b/lighthouserc.mobile.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 1,
+      "numberOfRuns": 2,
       "settings": {
         "formFactor": "mobile",
         "screenEmulation": {
@@ -22,7 +22,35 @@
       "throttlingMethod": "devtools"
     },
     "assert": {
-      "assertions": {}
+      "assertions": {
+        "categories:performance": [
+          "warn",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "largest-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 3200,
+            "aggregationMethod": "median"
+          }
+        ],
+        "total-blocking-time": [
+          "warn",
+          {
+            "maxNumericValue": 360,
+            "aggregationMethod": "median"
+          }
+        ],
+        "cumulative-layout-shift": [
+          "warn",
+          {
+            "maxNumericValue": 0.02,
+            "aggregationMethod": "pessimistic"
+          }
+        ]
+      }
     },
     "upload": {
       "target": "temporary-public-storage"


### PR DESCRIPTION
Define asserts de aviso para mobile (perf>=0.90, LCP<=3200ms, TBT<=360ms, CLS<=0.02) e estabiliza coleta (2 runs, devtools). Desktop intocado.