### PR TITLE
fix(middleware): normalize host and enforce 308 for /demo on apex+www

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,13 +2,14 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export function middleware(req: NextRequest) {
-  const host = req.headers.get("host") ?? "";
+  const rawHost = req.headers.get("host") ?? "";
+  const host = rawHost.toLowerCase().replace(/:\d+$/, ""); // normaliza host (sem porta)
   const url = req.nextUrl;
 
-  // Bloqueia /demo apenas no domínio apex (inclui www)
   const isApex = host === "crsetsolutions.com" || host === "www.crsetsolutions.com";
+  const isDemoPath = url.pathname === "/demo" || url.pathname.startsWith("/demo/");
 
-  if (isApex && (url.pathname === "/demo" || url.pathname.startsWith("/demo/"))) {
+  if (isApex && isDemoPath) {
     url.pathname = "/";
     return NextResponse.redirect(url, 308);
   }


### PR DESCRIPTION
Normalize host (lowercase, strip port). Enforce 308 redirect to '/' for /demo and /demo/* only on apex (crsetsolutions.com, www.crsetsolutions.com). Preview unaffected. After merge, validate with curl on / (200) and /demo (307/308 Location: /).