### PR TITLE
chore(guardrails): bloquear import de data-stream sem .client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+/** Guardrail: impede import errado do DataStream sem .client */
+module.exports = {
+  root: true,
+  extends: ["next", "next/core-web-vitals"],
+  rules: {
+    "no-restricted-imports": ["error", {
+      paths: [
+        { name: "@/components/ui/data-stream", message: 'Use "@/components/ui/data-stream.client"' }
+      ]
+    }]
+  }
+};

--- a/.github/workflows/guardrail-datastream.yml
+++ b/.github/workflows/guardrail-datastream.yml
@@ -1,0 +1,23 @@
+name: Guardrail - DataStream import
+
+on:
+  pull_request:
+  push:
+    branches: [ main, "**" ]
+
+jobs:
+  guardrail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate DataStream import usage
+        run: |
+          set -euo pipefail
+          if grep -R --line-number --exclude-dir=node_modules --exclude-dir=.next -E '@/components/ui/data-stream"[^.]' . ; then
+            echo "Import inválido de data-stream sem .client detectado"
+            exit 1
+          else
+            echo "OK: nenhum import inválido encontrado"
+          fi


### PR DESCRIPTION
Adiciona ESLint (no-restricted-imports) e job de CI para detetar imports de '@/components/ui/data-stream' sem '.client'. Sem alterações funcionais.