### PR TITLE
PR #A - Design tokens base e utilitarios glass

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -22,6 +22,19 @@
   --success: 16 185 129;         /* #10B981 */
   --warning: 245 158 11;         /* #F59E0B */
   --destructive: 239 68 68;      /* #EF4444 */
+
+  /* Neutral Scale */
+  --neutral-50: 248 250 252;    /* slate-50 */
+  --neutral-100: 241 245 249;   /* slate-100 */
+  --neutral-200: 226 232 240;   /* slate-200 */
+  --neutral-300: 203 213 225;   /* slate-300 */
+  --neutral-400: 148 163 184;   /* slate-400 */
+  --neutral-500: 100 116 139;   /* slate-500 */
+  --neutral-600: 71 85 105;     /* slate-600 */
+  --neutral-700: 51 65 85;      /* slate-700 */
+  --neutral-800: 30 41 59;      /* slate-800 */
+  --neutral-900: 15 23 42;      /* slate-900 */
+  --neutral-950: 2 6 23;        /* slate-950 */
 }
 
 /* Colors — Dark */
@@ -43,6 +56,19 @@
   --success: 34 197 94;
   --warning: 250 204 21;
   --destructive: 248 113 113;
+
+  /* Dark neutral overrides */
+  --neutral-50: 2 6 23;
+  --neutral-100: 15 23 42;
+  --neutral-200: 30 41 59;
+  --neutral-300: 51 65 85;
+  --neutral-400: 71 85 105;
+  --neutral-500: 100 116 139;
+  --neutral-600: 148 163 184;
+  --neutral-700: 203 213 225;
+  --neutral-800: 226 232 240;
+  --neutral-900: 241 245 249;
+  --neutral-950: 248 250 252;
 }
 
 /* Spacing (4px scale) */
@@ -51,23 +77,211 @@
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
+  --space-5: 20px;
   --space-6: 24px;
   --space-8: 32px;
+  --space-10: 40px;
   --space-12: 48px;
+  --space-16: 64px;
+  --space-20: 80px;
+  --space-24: 96px;
+  --space-32: 128px;
 
   /* Radius */
+  --radius-xs: 4px;
   --radius-sm: 8px;
   --radius-md: 12px;   /* default */
-  --radius-lg: 20px;
-  --radius-xl: 32px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-2xl: 24px;
+  --radius-3xl: 32px;
+  --radius-full: 9999px;
 
   /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
-  --shadow-md: 0 8px 24px rgba(0,0,0,0.08);
-  --shadow-lg: 0 18px 40px rgba(0,0,0,0.12);
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.06);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.1), 0 4px 6px rgba(0,0,0,0.05);
+  --shadow-xl: 0 20px 25px rgba(0,0,0,0.1), 0 8px 10px rgba(0,0,0,0.04);
+  --shadow-2xl: 0 25px 50px rgba(0,0,0,0.25);
+
+  /* Glass effects */
+  --glass-light: color-mix(in srgb, white 8%, transparent);
+  --glass-medium: color-mix(in srgb, white 12%, transparent);
+  --glass-strong: color-mix(in srgb, white 18%, transparent);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  
+  /* Grid pattern */
+  --grid-size: 40px;
+  --grid-color: rgba(0, 0, 0, 0.02);
+}
+
+[data-theme="dark"] {
+  --glass-light: color-mix(in srgb, black 20%, transparent);
+  --glass-medium: color-mix(in srgb, black 35%, transparent);
+  --glass-strong: color-mix(in srgb, black 50%, transparent);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --grid-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Typography Scale */
+:root {
+  --text-xs: 0.75rem;     /* 12px */
+  --text-sm: 0.875rem;    /* 14px */
+  --text-base: 1rem;      /* 16px */
+  --text-lg: 1.125rem;    /* 18px */
+  --text-xl: 1.25rem;     /* 20px */
+  --text-2xl: 1.5rem;     /* 24px */
+  --text-3xl: 1.875rem;   /* 30px */
+  --text-4xl: 2.25rem;    /* 36px */
+  --text-5xl: 3rem;       /* 48px */
+  --text-6xl: 3.75rem;    /* 60px */
+  --text-7xl: 4.5rem;     /* 72px */
+  --text-8xl: 6rem;       /* 96px */
+  --text-9xl: 8rem;       /* 128px */
+
+  /* Line heights */
+  --leading-none: 1;
+  --leading-tight: 1.25;
+  --leading-snug: 1.375;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.625;
+  --leading-loose: 2;
+}
+
+/* Z-index scale */
+:root {
+  --z-hide: -1;
+  --z-auto: auto;
+  --z-0: 0;
+  --z-10: 10;
+  --z-20: 20;
+  --z-30: 30;
+  --z-40: 40;
+  --z-50: 50;
+  --z-dropdown: 1000;
+  --z-sticky: 1020;
+  --z-fixed: 1030;
+  --z-modal-backdrop: 1040;
+  --z-modal: 1050;
+  --z-popover: 1060;
+  --z-tooltip: 1070;
+  --z-toast: 1080;
 }
 
 /* Hints p/ UA */
 :root { color-scheme: light; }
 [data-theme="dark"] { color-scheme: dark; }
-[data-theme="dark"] { color-scheme: dark; }
+
+/* Utility Classes */
+
+/* Glass Cards */
+.card-glass {
+  background: var(--glass-light);
+  backdrop-filter: blur(12px) saturate(150%);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+}
+
+.card-glass-medium {
+  background: var(--glass-medium);
+  backdrop-filter: blur(16px) saturate(180%);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+}
+
+.card-glass-strong {
+  background: var(--glass-strong);
+  backdrop-filter: blur(20px) saturate(200%);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+}
+
+/* Shadow Elevations */
+.shadow-elev-1 { box-shadow: var(--shadow-sm); }
+.shadow-elev-2 { box-shadow: var(--shadow-md); }
+.shadow-elev-3 { box-shadow: var(--shadow-lg); }
+.shadow-elev-4 { box-shadow: var(--shadow-xl); }
+.shadow-elev-5 { box-shadow: var(--shadow-2xl); }
+
+/* Grid Background */
+.bg-grid {
+  background-image: 
+    linear-gradient(var(--grid-color) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+  background-size: var(--grid-size) var(--grid-size);
+  background-position: -1px -1px;
+}
+
+/* Gradient Backgrounds */
+.bg-gradient-primary {
+  background: linear-gradient(135deg, 
+    rgb(var(--primary)) 0%, 
+    rgb(var(--secondary)) 100%);
+}
+
+.bg-gradient-accent {
+  background: linear-gradient(135deg, 
+    rgb(var(--accent)) 0%, 
+    rgb(var(--primary)) 100%);
+}
+
+.bg-gradient-subtle {
+  background: linear-gradient(135deg, 
+    rgb(var(--neutral-50)) 0%, 
+    rgb(var(--neutral-100)) 100%);
+}
+
+[data-theme="dark"] .bg-gradient-subtle {
+  background: linear-gradient(135deg, 
+    rgb(var(--neutral-900)) 0%, 
+    rgb(var(--neutral-800)) 100%);
+}
+
+/* Focus Ring */
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--bg)), 0 0 0 4px rgb(var(--ring));
+  border-radius: var(--radius-md);
+}
+
+/* Animations */
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { 
+    opacity: 0; 
+    transform: translateY(20px); 
+  }
+  to { 
+    opacity: 1; 
+    transform: translateY(0); 
+  }
+}
+
+@keyframes scale-in {
+  from { 
+    opacity: 0; 
+    transform: scale(0.95); 
+  }
+  to { 
+    opacity: 1; 
+    transform: scale(1); 
+  }
+}
+
+.animate-fade-in { animation: fade-in 0.3s ease-out; }
+.animate-slide-up { animation: slide-up 0.4s ease-out; }
+.animate-scale-in { animation: scale-in 0.2s ease-out; }
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-slide-up,
+  .animate-scale-in {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Expande os design tokens com cores neutras completas, espacamentos, radius, sombras e efeitos glass. Adiciona utilitarios card-glass, shadow-elev e bg-grid conforme especificado. Fundacao opt-in sem alterar HTML existente.