### PR TITLE
fix: resolve SEO audit conflicts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,6 +146,34 @@ export default function Page() {
 
       {/* Mascot Assistant */}
       <MascotBubble />
+
+      {/* JSON-LD Structured Data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "name": "CRSET Solutions",
+            "description": "Automação e AGI aplicada ao negócio. Resultados práticos, sem circo.",
+            "url": "https://crsetsolutions.com",
+            "logo": "https://crsetsolutions.com/logo.png",
+            "sameAs": [
+              "https://agi.crsetsolutions.com"
+            ],
+            "contactPoint": {
+              "@type": "ContactPoint",
+              "contactType": "customer service",
+              "url": "https://crsetsolutions.com/#contact"
+            },
+            "offers": {
+              "@type": "AggregateOffer",
+              "description": "Serviços de automação e AGI para empresas",
+              "url": "https://crsetsolutions.com/servicos"
+            }
+          })
+        }}
+      />
     </main>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 function normalizeBaseUrl(raw: string | undefined): string {
   // remove espaços/quebras (incl. \n), garantir protocolo e tirar trailing slashes
   const cleaned = (raw ?? "").trim().replace(/\s+/g, "");
-  const withProto = /^https?:\/\//i.test(cleaned) ? cleaned : "https://crset.pt";
+  const withProto = /^https?:\/\//i.test(cleaned) ? cleaned : "https://crsetsolutions.com";
   return withProto.replace(/\/+$/, "");
 }
 

--- a/src/app/servicos/[slug]/page.tsx
+++ b/src/app/servicos/[slug]/page.tsx
@@ -6,7 +6,14 @@ import { pricePair, PRICE_FALLBACKS } from "@/lib/prices";
 import { SERVICES_CONFIG, getServiceBySlug, getAllSlugs } from "@/lib/services-config";
 import type { Metadata } from "next";
 export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
-  return { openGraph: { url: `https://crset-solutions-frontend.vercel.app/servicos/${params.slug}` }, alternates: { canonical: `https://crset-solutions-frontend.vercel.app/servicos/${params.slug}` },};
+  // Use NEXT_PUBLIC_SITE_URL com fallback para crsetsolutions.com
+  const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://crsetsolutions.com';
+  const canonicalUrl = `${SITE_URL}/servicos/${params.slug}`;
+  
+  return { 
+    openGraph: { url: canonicalUrl }, 
+    alternates: { canonical: canonicalUrl },
+  };
 }
 
 interface ServicePageProps {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,18 +5,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const isProd = process.env.VERCEL_ENV === "production";
   if (!isProd) return []; // previews/dev: sitemap vazio
 
+  // Use NEXT_PUBLIC_SITE_URL com fallback para crsetsolutions.com
+  const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://crsetsolutions.com';
   const now = new Date().toISOString();
   const staticRoutes = ["/", "/servicos", "/precos", "/centro-de-ajuda"];
 
   return [
-    ...staticRoutes.map((p) => ({
-      url: p, // relativo - o Next prefixa com o host
+    ...staticRoutes.map((path) => ({
+      url: new URL(path, SITE_URL).href, // URL absoluto
       lastModified: now,
       changeFrequency: "weekly" as const,
-      priority: 0.7,
+      priority: path === "/" ? 0.9 : 0.7,
     })),
     ...getAllSlugs().map((slug) => ({
-      url: `/servicos/${slug}`, // relativo
+      url: new URL(`/servicos/${slug}`, SITE_URL).href, // URL absoluto
       lastModified: now,
       changeFrequency: "weekly" as const,
       priority: 0.8,


### PR DESCRIPTION
Corrige conflitos identificados na auditoria SEO:

✅ **sitemap.xml**: URLs absolutos com SITE_URL
✅ **canonicals /servicos/***: SITE_URL em vez de vercel.app  
✅ **robots.txt**: fallback para crsetsolutions.com
✅ **JSON-LD**: Schema.org na home (Organization)

**Testes**: Build ✅, Lint ✅, APIs ✅, Rotas ✅